### PR TITLE
Add support for fuzzing using cargo fuzz

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+
+[package]
+name = "seq_io-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[dependencies]
+criterion = "*"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.seq_io]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+
+[[bin]]
+name = "single_thread"
+path = "fuzz_targets/single_thread.rs"

--- a/fuzz/fuzz_targets/single_thread.rs
+++ b/fuzz/fuzz_targets/single_thread.rs
@@ -1,0 +1,21 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate seq_io;
+extern crate criterion;
+
+use std::io::Cursor;
+use seq_io::fastq::{Reader, Record};
+
+
+fuzz_target!(|data: &[u8]| {
+    let reader = Cursor::new(data);
+    let mut reader = Reader::new(reader);
+    let mut count: usize = 0;
+
+    while let Some(result) = reader.next() {
+        if let Ok(record) = result {
+            count += record.seq().len();
+        }
+    }
+    criterion::black_box(count);
+});


### PR DESCRIPTION
I've been fuzzing seq_io, and found an issue.
With this PR applied, run
```
env RUST_BACKTRACE=1 cargo fuzz run single_thread -- -max_len=100 -only_ascii=1
```
I'm getting a panic:

<details>

```
INFO: Seed: 3182441194
INFO: Loaded 1 modules   (1091157 guards): 1091157 [0x109391148, 0x1097baa9c), 
INFO:       76 files found in /Users/adrianseyboldt/git/seq_io/fuzz/corpus/single_thread
INFO: seed corpus: files: 76 min: 1b max: 100b total: 3390b rss: 50Mb
#77	INITED cov: 3516 ft: 6385 corp: 28/615b exec/s: 0 rss: 67Mb
#98	REDUCE cov: 3516 ft: 6385 corp: 28/601b exec/s: 0 rss: 68Mb L: 18/82 MS: 1 EraseBytes-
thread '<unnamed>' panicked at 'slice index starts at 1 but ends at 0', libcore/slice/mod.rs:1941:5
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:227
   4: <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get
             at libstd/panicking.rs:475
   5: std::panicking::continue_panic_fmt
             at libstd/panicking.rs:390
   6: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:325
   7: core::ptr::drop_in_place
             at libcore/panicking.rs:77
   8: core::ptr::drop_in_place
             at libcore/slice/mod.rs:1941
   9: core::alloc::Layout::align
             at /Users/travis/build/rust-lang/rust/src/libcore/slice/mod.rs:2098
  10: core::str::traits::<impl core::cmp::PartialEq for str>::eq
             at /Users/travis/build/rust-lang/rust/src/libcore/slice/mod.rs:1917
  11: seq_io::fastq::BufferPosition::head
             at ./src/fastq.rs:750
  12: <seq_io::fastq::Reader<R, S>>::get_error_pos
             at ./src/fastq.rs:322
  13: <seq_io::fastq::Reader<R, S>>::next_complete
             at ./src/fastq.rs:368
  14: <seq_io::fastq::Reader<R, S>>::proceed
             at ./src/fastq.rs:119
  15: <seq_io::fastq::Reader<R, S>>::next
             at ./src/fastq.rs:142
  16: asan.module_dtor
             at fuzz_targets/single_thread.rs:15
  17: libfuzzer_sys::test_input_wrap::{{closure}}
             at /Users/adrianseyboldt/.cargo/git/checkouts/libfuzzer-sys-e07fde05820d7bc6/86bcaac/src/lib.rs:11
  18: asan.module_dtor
             at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
==71378== ERROR: libFuzzer: deadly signal
    #0 0x10b582bf7 in __sanitizer_print_stack_trace (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x62bf7)
    #1 0x108fa7cfb in fuzzer::Fuzzer::CrashCallback() FuzzerLoop.cpp:233
    #2 0x108fa7cad in fuzzer::Fuzzer::StaticCrashSignalCallback() FuzzerLoop.cpp:206
    #3 0x109005ea7 in fuzzer::CrashHandler(int, __siginfo*, void*) FuzzerUtilPosix.cpp:36
    #4 0x7fff6d803f59 in _sigtramp (libsystem_platform.dylib:x86_64+0x1f59)
    #5 0x109304007  (single_thread):x86_64+0x102a0f007)
    #6 0x7fff6d5a11ad in abort (libsystem_c.dylib:x86_64+0x5d1ad)
    #7 0x109055318 in panic_abort::__rust_start_panic::abort::h634520f98782cd18 lib.rs:61
    #8 0x109055308 in __rust_start_panic lib.rs:56
    #9 0x109049e28 in rust_panic panicking.rs:523
    #10 0x109049e01 in std::panicking::rust_panic_with_hook::h63bac89c0b130b1b panicking.rs:495
    #11 0x10904990c in std::panicking::continue_panic_fmt::hca36ebb6f3aa63ac panicking.rs:390
    #12 0x1090497f8 in rust_begin_unwind panicking.rs:325
    #13 0x1090644e1 in core::panicking::panic_fmt::hf13b65b6154af8d5 panicking.rs:77
    #14 0x109057ff4 in core::slice::slice_index_order_fail::h43a32eb72008320c mod.rs:1941
    #15 0x108f2e66e in _$LT$core..ops..range..Range$LT$usize$GT$$u20$as$u20$core..slice..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$::index::h0faf9fbc7c59c6ff mod.rs:2098
    #16 0x1089b1695 in core::slice::_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$::index::h18f44fda58e6d108 mod.rs:1917
    #17 0x106918df2 in seq_io::fastq::BufferPosition::head::h255a495d6fa69647 fastq.rs:750
    #18 0x106901a4c in _$LT$seq_io..fastq..Reader$LT$R$C$$u20$S$GT$$GT$::get_error_pos::hb03a14f6d76fb403 fastq.rs:322
    #19 0x106904db7 in _$LT$seq_io..fastq..Reader$LT$R$C$$u20$S$GT$$GT$::next_complete::hc1c47ae20e64b998 fastq.rs:368
    #20 0x106911419 in _$LT$seq_io..fastq..Reader$LT$R$C$$u20$S$GT$$GT$::proceed::hc5c2d0ce376e739b fastq.rs:119
    #21 0x10690fa5f in _$LT$seq_io..fastq..Reader$LT$R$C$$u20$S$GT$$GT$::next::h131e1813100d008b fastq.rs:142
    #22 0x1068fbabf in rust_fuzzer_test_input single_thread.rs:15
    #23 0x108fa42de in libfuzzer_sys::test_input_wrap::_$u7b$$u7b$closure$u7d$$u7d$::h0a71f7a9044d8747 lib.rs:11
    #24 0x108fa56e0 in std::panicking::try::do_call::h6dffe5f7048c2351 panicking.rs:310
    #25 0x1090552fb in __rust_maybe_catch_panic lib.rs:39
    #26 0x108fa4c12 in std::panicking::try::hee4100871ea2e35d panicking.rs:289
    #27 0x108fa018f in std::panic::catch_unwind::h02670d829b3a0291 panic.rs:392
    #28 0x108fa3b01 in LLVMFuzzerTestOneInput lib.rs:9
    #29 0x108faa811 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) FuzzerLoop.cpp:515
    #30 0x108fa9c6a in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) FuzzerLoop.cpp:440
    #31 0x108faff03 in fuzzer::Fuzzer::MutateAndTestOne() FuzzerLoop.cpp:648
    #32 0x108fb27d8 in fuzzer::Fuzzer::Loop(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, fuzzer::fuzzer_allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) FuzzerLoop.cpp:775
    #33 0x108ff1961 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) FuzzerDriver.cpp:754
    #34 0x10901e87f in main FuzzerMain.cpp:20
    #35 0x7fff6d4f5014 in start (libdyld.dylib:x86_64+0x1014)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 3 EraseBytes-CopyPart-EraseBytes-; base unit: d95527d899043c4adbc0db32a303b7221f1f05d5
0xa,0x2a,
\x0a*
artifact_prefix='/Users/adrianseyboldt/git/seq_io/fuzz/artifacts/single_thread/'; Test unit written to /Users/adrianseyboldt/git/seq_io/fuzz/artifacts/single_thread/crash-f9583eb831f52cfe1fd177744a6b511382ab8df6
Base64: Cio=
```

</details>

I'm the fastq-rs author by the way. I love what you've been doing with seq_io. :-)