### PR TITLE
fix: bugs with pre-initialized fastq reader

### DIFF
--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -731,7 +731,7 @@ pub struct RefRecord<'a> {
     buf_pos: &'a BufferPosition,
 }
 
-impl<'a> Record for RefRecord<'a> {
+impl Record for RefRecord<'_> {
     #[inline]
     fn head(&self) -> &[u8] {
         trim_cr(&self.buffer[self.buf_pos.start + 1..*self.buf_pos.seq_pos.first().unwrap()])
@@ -767,7 +767,7 @@ impl<'a> Record for RefRecord<'a> {
     }
 }
 
-impl<'a> RefRecord<'a> {
+impl RefRecord<'_> {
     /// Return an iterator over all sequence lines in the data
     #[inline]
     pub fn seq_lines(&self) -> SeqLines {
@@ -831,7 +831,7 @@ impl<'a> RefRecord<'a> {
         let data = &self.buffer[self.buf_pos.start..*self.buf_pos.seq_pos.last().unwrap()];
         writer.write_all(data)?;
         if *data.last().unwrap() != b'\n' {
-            writer.write_all(&[b'\n'])?;
+            writer.write_all(b"\n")?;
         }
         Ok(())
     }
@@ -870,7 +870,7 @@ impl<'a> DoubleEndedIterator for SeqLines<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for SeqLines<'a> {
+impl ExactSizeIterator for SeqLines<'_> {
     #[inline]
     fn len(&self) -> usize {
         self.len

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -177,16 +177,17 @@ where
             return None;
         }
 
-        if !self.initialized() {
-            if !try_opt!(self.init()) {
-                return None;
-            }
-            if !try_opt!(self.find()) {
-                return Some(Ok(()));
-            }
-        } else if !try_opt!(self.next_complete()) {
+        if !self.initialized() && !try_opt!(self.init()) {
             return None;
-        };
+        }
+
+        if !self.buf_pos.is_new() {
+            self.next_pos();
+        }
+
+        if !try_opt!(self.find()) && !try_opt!(self.next_complete()) {
+            return None;
+        }
 
         rset.buffer.clear();
         rset.buffer.extend(self.get_buf());

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -826,7 +826,7 @@ pub struct RefRecord<'a> {
     buf_pos: &'a BufferPosition,
 }
 
-impl<'a> Record for RefRecord<'a> {
+impl Record for RefRecord<'_> {
     #[inline]
     fn head(&self) -> &[u8] {
         self.buf_pos.head(self.buffer)
@@ -843,7 +843,7 @@ impl<'a> Record for RefRecord<'a> {
     }
 }
 
-impl<'a> RefRecord<'a> {
+impl RefRecord<'_> {
     #[inline]
     pub fn to_owned_record(&self) -> OwnedRecord {
         OwnedRecord {

--- a/tests/fastq.rs
+++ b/tests/fastq.rs
@@ -341,3 +341,27 @@ fn test_fastq_write_record_unchanged() {
     }
     assert_eq!(&out, &FASTQ);
 }
+
+#[test]
+fn test_fastq_read_record_set_with_initialized_reader() {
+    let mut out = vec![];
+    let mut rdr = Reader::new(FASTQ);
+
+    // Read + Write the first record
+    if let Some(Ok(r)) = rdr.next() {
+        r.write(&mut out).unwrap();
+    }
+
+    // Read the rest of the records
+    let mut rset = RecordSet::default();
+    if let Some(res) = rdr.read_record_set(&mut rset) {
+        res.unwrap();
+    }
+
+    // Write the rest of the records
+    for r in rset.into_iter() {
+        r.write(&mut out).unwrap();
+    }
+
+    assert_eq!(&out, &FASTQ);
+}


### PR DESCRIPTION
This is a fix for my issue #20 where 

1. small fastqs will fail with unexpected EOF on pre-initialized readers 
2. records processed by initialized readers are duplicated in the record sets.

This problem also exists for fasta, but I was not able to fix it in the same way. 